### PR TITLE
fix: ANSI escape sequences on Windows

### DIFF
--- a/index.py
+++ b/index.py
@@ -3,9 +3,9 @@ import json
 import inspect
 import sys
 
-from colorama import Fore, Style
+from colorama import Fore, Style, just_fix_windows_console
 
-colorama.just_fix_windows_console()
+just_fix_windows_console()
 
 # Make sure that the user is running Python 3.8 or higher
 if sys.version_info < (3, 8):

--- a/index.py
+++ b/index.py
@@ -5,6 +5,8 @@ import sys
 
 from colorama import Fore, Style
 
+colorama.just_fix_windows_console()
+
 # Make sure that the user is running Python 3.8 or higher
 if sys.version_info < (3, 8):
     exit("Python 3.8 or higher is required to run this bot!")


### PR DESCRIPTION
Adds a call to `colorama.just_fix_windows_console` so on the old Windows terminal ANSI escape sequences for colour /  style appear as they should.