### PR TITLE
Add docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,4 @@
-FROM alpine
-
-RUN apk add --update --no-cache python3 py3-pip
+FROM python:3-alpine
 
 WORKDIR /app
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,14 @@
+FROM alpine
+
+RUN apk add --update --no-cache python3 py3-pip
+
+WORKDIR /app
+
+COPY ./requirements.txt ./requirements.txt
+
+RUN pip3 install -r requirements.txt
+
+COPY ./index.py ./index.py
+
+COPY ./docker/entrypoint.sh /entrypoint.sh
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+
+# check if the BOT_TOKEN is set
+if [ -z "$BOT_TOKEN" ]; then
+    echo "BOT_TOKEN environment variable is missing"
+    exit 1
+fi
+
+# create config.json file with the BOT_TOKEN in /app
+echo "{\"token\":\"${BOT_TOKEN}\"}" > /app/config.json
+
+# run the bot
+cd /app
+python3 index.py "$@"


### PR DESCRIPTION
This pr adds a Dockerfile and a Docker entrypoint script that creates the `config.json` file inside of the container based on the `BOT_TOKEN` environment variable. 

This makes it very easy to permanently self-host this bot on any OCI-compatible container runtime.

to test it using my pre-built image run
```bash
docker run --rm -it -e BOT_TOKEN=<BOT TOKEN HERE> ghcr.io/dumbaspl/givemebadge
```